### PR TITLE
Add support for apparmor hats

### DIFF
--- a/apparmor.c
+++ b/apparmor.c
@@ -14,11 +14,35 @@ static struct uwsgi_apparmor {
 } uapparmor;
 
 static struct uwsgi_option apparmor_options[] = {
-	{"apparmor-profile", required_argument, 0, "set apparmor profile before privileges drop", uwsgi_opt_set_str, &uapparmor.profile, 0},
+	{
+		.name     = "apparmor-profile",
+		.type     = required_argument,
+		.shortcut = 0,
+		.help     = "set apparmor profile before privileges drop",
+		.func     = uwsgi_opt_set_str,
+		.data     = &uapparmor.profile,
+		.flags    = 0
+	},
 #if UWSGI_PLUGIN_API > 1
-	{"emperor-apparmor-attr", required_argument, 0, "set vassal apparmor profile using the specified attr", uwsgi_opt_set_str, &uapparmor.emperor_apparmor_attr, 0},
+	{
+		.name     = "emperor-apparmor-attr",
+		.type     = required_argument,
+		.shortcut = 0,
+		.help     = "set vassal apparmor profile using the specified attr",
+		.func     = uwsgi_opt_set_str,
+		.data     = &uapparmor.emperor_apparmor_attr,
+		.flags    = 0
+	},
 #endif
-	{"emperor-apparmor", required_argument, 0, "set vassals apparmor profile", uwsgi_opt_set_str, &uapparmor.emperor_apparmor, 0},
+	{
+		.name     = "emperor-apparmor",
+		.type     = required_argument,
+		.shortcut = 0,
+		.help     = "set vassals apparmor profile",
+		.func     = uwsgi_opt_set_str,
+		.data     = &uapparmor.emperor_apparmor,
+		.flags    = 0
+	},
 	UWSGI_END_OF_OPTIONS
 };
 

--- a/apparmor.c
+++ b/apparmor.c
@@ -7,10 +7,12 @@
 
 static struct uwsgi_apparmor {
 	char *profile;
+	char *hat;
 #if UWSGI_PLUGIN_API > 1
 	char *emperor_apparmor_attr;
 #endif
 	char *emperor_apparmor;
+	char *emperor_apparmor_hat;
 } uapparmor;
 
 static struct uwsgi_option apparmor_options[] = {
@@ -21,6 +23,15 @@ static struct uwsgi_option apparmor_options[] = {
 		.help     = "set apparmor profile before privileges drop",
 		.func     = uwsgi_opt_set_str,
 		.data     = &uapparmor.profile,
+		.flags    = 0
+	},
+	{
+		.name     = "apparmor-hat",
+		.type     = required_argument,
+		.shortcut = 0,
+		.help     = "set apparmor hat before privileges drop",
+		.func     = uwsgi_opt_set_str,
+		.data     = &uapparmor.hat,
 		.flags    = 0
 	},
 #if UWSGI_PLUGIN_API > 1
@@ -43,8 +54,48 @@ static struct uwsgi_option apparmor_options[] = {
 		.data     = &uapparmor.emperor_apparmor,
 		.flags    = 0
 	},
+	{
+		.name     = "emperor-apparmor-hat",
+		.type     = required_argument,
+		.shortcut = 0,
+		.help     = "set vassals apparmor hat",
+		.func     = uwsgi_opt_set_str,
+		.data     = &uapparmor.emperor_apparmor_hat,
+		.flags    = 0
+	},
 	UWSGI_END_OF_OPTIONS
 };
+
+static void uwsgi_change_hat(const char *hat) {
+	char new_con[1024] = {0};
+	size_t new_con_len;
+	char *con = NULL;
+	int rc;
+
+	rc = aa_getcon(&con, NULL);
+	if (rc == -1) {
+		uwsgi_error("uwsgi_change_hat()/aa_getcon()");
+		exit(1);
+	}
+
+	new_con_len = strlen(con) + 2 + strlen(uapparmor.hat);
+	rc = snprintf(new_con, sizeof(new_con),
+		      "%s//%s", con, hat);
+	free(con);
+	if (rc != new_con_len) {
+		uwsgi_error("uwsgi_change_hat()/snprintf()");
+		exit(1);
+	}
+
+	uwsgi_log("[apparmor] changing hat to \"%s\" ...\n",
+		  hat);
+
+	rc = aa_change_profile(new_con);
+	if (rc > 0) {
+		uwsgi_error("uwsgi_change_hat()/aa_change_profile()");
+		exit(1);
+	}
+}
 
 #if UWSGI_PLUGIN_API > 1
 static void vassal_apply_apparmor(struct uwsgi_instance *ui, char **argv) {
@@ -52,26 +103,39 @@ static void vassal_apply_apparmor(struct uwsgi_instance *ui, char **argv) {
 static void vassal_apply_apparmor(struct uwsgi_instance *ui) {
 #endif
 	char *profile = uapparmor.emperor_apparmor;
+	const char *hat = uapparmor.emperor_apparmor_hat;
+
 #if UWSGI_PLUGIN_API > 1
 	if (uapparmor.emperor_apparmor_attr) {
 		profile = vassal_attr_get(ui, uapparmor.emperor_apparmor_attr);
 	}
 #endif
-	if (!profile) return;
 
-	uwsgi_log("[apparmor] setting profile \"%s\" ...\n", profile);
-	if (aa_change_profile(profile)) {
-                uwsgi_error("vassal_apply_apparmor()/aa_change_profile()");
-                exit(1);
-        }
+	if (hat != NULL) {
+		uwsgi_change_hat(hat);
+	}
+
+	if (profile != NULL) {
+		uwsgi_log("[apparmor] setting profile \"%s\" ...\n", profile);
+		if (aa_change_profile(profile)) {
+			uwsgi_error("vassal_apply_apparmor()/aa_change_profile()");
+			exit(1);
+		}
+	}
 }
 
 static void apply_apparmor_before_privileges_drop() {
-	if (!uapparmor.profile) return;
-	uwsgi_log("[apparmor] setting profile \"%s\" ...\n", uapparmor.profile);
-	if (aa_change_profile(uapparmor.profile)) {
-		uwsgi_error("apply_apparmor_before_privileges_drop()/aa_change_profile()");
-		exit(1);
+	if (uapparmor.hat != NULL) {
+		uwsgi_change_hat(uapparmor.hat);
+	}
+
+	if (uapparmor.profile != NULL) {
+		uwsgi_log("[apparmor] setting profile \"%s\" ...\n",
+			  uapparmor.profile);
+		if (aa_change_profile(uapparmor.profile)) {
+			uwsgi_error("apply_apparmor_before_privileges_drop()/aa_change_profile()");
+			exit(1);
+		}
 	}
 }
 


### PR DESCRIPTION
This adds support for apparmor has in the form profile//hat

Here is the profile `usr.sbin.wsgi`:

```
#
# LICENSED UNDER AGPL 3.0
#
#include <tunables/global>
profile uwsgi /usr/sbin/uwsgi flags=(attach_disconnected, complain) {
  #include <abstractions/base>
  #include <abstractions/nameservice>

  capability net_admin,
  capability chown,
  capability setgid,
  capability setuid,

  /usr/sbin/uwsgi mrix,

  /etc/uwsgi/* r,
  /etc/uwsgi/vassals/ r,
  /etc/uwsgi/vassals/* r,

  /proc/@{pid}/attr/current rw,
  /proc/sys/net/core/somaxconn r,
  /proc/sys/kernel/ngroups_max r,
  /sys/devices/system/cpu/online r,

  /var/log/uwsgi/uwsgi.log rw,

  /run/uwsgi/uwsgi-*.socket rwlk,
  /run/uwsgi/uwsgi-*.sock   rwlk,
  /run/uwsgi/uwsgi.pid rwlk,

  deny / rw,

  signal (send) peer=uwsgi//*,

  change_profile -> uwsgi//*,

  #include <uwsgi.d>
  #include <local/usr.sbin.uwsgi>
}
```

You can then create a hat in `uswgi.d/pgadmin` for example:

```
  profile pgadmin4 flags=(attach_disconnected) {
    owner /var/lib/pgadmin/ r,
    ...
  }
```